### PR TITLE
feat: support SourceMap mapping

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+    patch:
+      default:
+        target: 80%

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,5 @@ jobs:
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
+        files: coverage/lcov.info
         fail_ci_if_error: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
     },
   },
   testPathIgnorePatterns: ['dist'],
+  coverageReporters: ['text', process.env.CI === 'true' ? 'lcovonly' : 'lcov'],
 };

--- a/src/__snapshots__/transform.test.ts.snap
+++ b/src/__snapshots__/transform.test.ts.snap
@@ -21,10 +21,12 @@ export declare enum ComputedEnum {
     J = \\"12\\",
     K = 1
 }
-export declare enum RegularEnum {
+declare enum NonExportEnum {
     A = 0,
     B = 1
 }
+declare function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum): SomeEnum.D | ComputedEnum | NonExportEnum;
+export default SomeFunc;
 "
 `;
 
@@ -49,12 +51,21 @@ export const ComputedEnum = {
     J: \\"12\\",
     K: 1
 };
-export var RegularEnum;
-(function (RegularEnum) {
-    RegularEnum[RegularEnum[\\"A\\"] = 0] = \\"A\\";
-    RegularEnum[RegularEnum[\\"B\\"] = 1] = \\"B\\";
-})(RegularEnum || (RegularEnum = {}));
+const Value = 0.5;
+var NonExportEnum;
+(function (NonExportEnum) {
+    NonExportEnum[NonExportEnum[\\"A\\"] = 0] = \\"A\\";
+    NonExportEnum[NonExportEnum[\\"B\\"] = 1] = \\"B\\";
+})(NonExportEnum || (NonExportEnum = {}));
+function SomeFunc(inlineSomeEnum, inlineComputedEnum) {
+    if (inlineSomeEnum === 0 /* A */)
+        return 1000 /* D */;
+    if (inlineComputedEnum === -2 /* D */)
+        return 4 /* E */;
+    return Math.random() > Value ? NonExportEnum.A : NonExportEnum.B;
+}
+export default SomeFunc;
 //# sourceMappingURL=const-enum.js.map"
 `;
 
-exports[`transform export const enum into object literal test-case/const-enum.js.map 1`] = `"{\\"version\\":3,\\"file\\":\\"const-enum.js\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"const-enum.ts\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,MAAM,OAAY,QAAQ;IACxB,IAAC;IACD,IAAC;IACD,UAAW;IACX,OAAQ;IACR,OAAC;EACF;AAED,MAAM,OAAY,YAAY;IAC5B,IAAC;IACD,IAAC;IACD,IAAC;IACD,KAAU;IACV,IAAU;IACV,KAAc;IACd,OAAuB;IACvB,KAA4B;IAC5B,MAAgB;IAChB,OAAa;IACb,IAAoB;EACrB;AAED,MAAM,CAAN,IAAY,WAGX;AAHD,WAAY,WAAW;IACrB,uCAAC,CAAA;IACD,uCAAC,CAAA;AACH,CAAC,EAHW,WAAW,KAAX,WAAW,QAGtB\\"}"`;
+exports[`transform export const enum into object literal test-case/const-enum.js.map 1`] = `"{\\"version\\":3,\\"file\\":\\"const-enum.js\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"const-enum.ts\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,MAAM,OAAY,QAAQ;IACxB,IAAC;IACD,IAAC;IACD,UAAW;IACX,OAAQ;IACR,OAAC;EACF;AAED,MAAM,OAAY,YAAY;IAC5B,IAAC;IACD,IAAC;IACD,IAAC;IACD,KAAU;IACV,IAAU;IACV,KAAc;IACd,OAAuB;IACvB,KAA4B;IAC5B,MAAgB;IAChB,OAAa;IACb,IAAoB;EACrB;AAED,MAAM,KAAK,GAAG,GAAG,CAAC;AAElB,IAAK,aAGJ;AAHD,WAAK,aAAa;IAChB,2CAAC,CAAA;IACD,2CAAC,CAAA;AACH,CAAC,EAHI,aAAa,KAAb,aAAa,QAGjB;AAED,SAAS,QAAQ,CAAC,cAAwB,EAAE,kBAAgC;IAC1E,IAAI,cAAc,cAAe;QAAE,oBAAkB;IACrD,IAAI,kBAAkB,eAAmB;QAAE,iBAAsB;IACjE,OAAO,IAAI,CAAC,MAAM,EAAE,GAAG,KAAK,CAAC,CAAC,CAAC,aAAa,CAAC,CAAC,CAAC,CAAC,CAAC,aAAa,CAAC,CAAC,CAAC;AACnE,CAAC;AAED,eAAe,QAAQ,CAAC\\"}"`;

--- a/src/__snapshots__/transform.test.ts.snap
+++ b/src/__snapshots__/transform.test.ts.snap
@@ -54,5 +54,7 @@ export var RegularEnum;
     RegularEnum[RegularEnum[\\"A\\"] = 0] = \\"A\\";
     RegularEnum[RegularEnum[\\"B\\"] = 1] = \\"B\\";
 })(RegularEnum || (RegularEnum = {}));
-"
+//# sourceMappingURL=const-enum.js.map"
 `;
+
+exports[`transform export const enum into object literal test-case/const-enum.js.map 1`] = `"{\\"version\\":3,\\"file\\":\\"const-enum.js\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"const-enum.ts\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,MAAM,OAAY,QAAQ;IACxB,IAAC;IACD,IAAC;IACD,UAAW;IACX,OAAQ;IACR,OAAC;EACF;AAED,MAAM,OAAY,YAAY;IAC5B,IAAC;IACD,IAAC;IACD,IAAC;IACD,KAAU;IACV,IAAU;IACV,KAAc;IACd,OAAuB;IACvB,KAA4B;IAC5B,MAAgB;IAChB,OAAa;IACb,IAAoB;EACrB;AAED,MAAM,CAAN,IAAY,WAGX;AAHD,WAAY,WAAW;IACrB,uCAAC,CAAA;IACD,uCAAC,CAAA;AACH,CAAC,EAHW,WAAW,KAAX,WAAW,QAGtB\\"}"`;

--- a/src/transform.test.ts
+++ b/src/transform.test.ts
@@ -1,6 +1,5 @@
 import ts from 'typescript';
 import transform from './transform';
-
 describe('transform export const enum into object literal', () => {
   const output = compile('test-case/const-enum.ts');
 
@@ -20,6 +19,7 @@ function compile(fileName: string): Output {
       module: ts.ModuleKind.ES2015,
       preserveConstEnums: true,
       declaration: true,
+      sourceMap: true,
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
     },
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,9 +69,9 @@ export function evaluate(
   return undefined;
 }
 
-export function hasModifier(node: ts.Node, modifier: ts.SyntaxKind): boolean {
+export function getModifier(node: ts.Node, modifier: ts.SyntaxKind) {
   return (
     node.modifiers
-    && node.modifiers.some((mod: ts.Modifier) => mod.kind === modifier)
+    && node.modifiers.find((mod: ts.Modifier) => mod.kind === modifier)
   );
 }

--- a/test-case/const-enum.ts
+++ b/test-case/const-enum.ts
@@ -20,7 +20,17 @@ export const enum ComputedEnum {
   K = B & 1000 + H / 2,
 }
 
-export enum RegularEnum {
+const Value = 0.5;
+
+enum NonExportEnum {
   A,
   B,
 }
+
+function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum) {
+  if (inlineSomeEnum === SomeEnum.A) return SomeEnum.D;
+  if (inlineComputedEnum === ComputedEnum.D) return ComputedEnum.E;
+  return Math.random() > Value ? NonExportEnum.A : NonExportEnum.B;
+}
+
+export default SomeFunc;


### PR DESCRIPTION
The source map doesn't map to generated object literal after transformed. We should update the source map range after transformation.

Using [this tool](https://github.com/sokra/source-map-visualization/) to analyze the output source map:

You can see before this PR, there's no correct mapping from enum member to property assignment:
![image](https://user-images.githubusercontent.com/5862369/152530875-78d92ce0-7c8c-4652-a22c-012018da0dca.png)

After this PR, the mapping works.
![image](https://user-images.githubusercontent.com/5862369/152530920-92213e8b-b4e5-4071-885e-c06b20b9a5f3.png)
