### PR TITLE
Feat/support export later

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,3 @@ export default {
   ],
 };
 ```
-
-# Caveats
-
-Currently, only immediate export const enum works. For example:
-
-```ts
-// The following works
-export const enum WorkingEnum {}
-
-// The following doesn't work
-const enum FailingEnum {}
-export FailEnum;
-```
-
-This may be fixed in future release.

--- a/src/__snapshots__/transform.test.ts.snap
+++ b/src/__snapshots__/transform.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transform export const enum into object literal test-case/const-enum.d.ts 1`] = `
-"export declare enum SomeEnum {
+"declare enum SomeEnum {
     A = 0,
     B = 1,
     C = \\"hello\\",
     D = 1000,
     E = 1001
 }
-export declare enum ComputedEnum {
+declare enum ComputedEnum {
     A = 0,
     B = 1,
     C = 2,
@@ -21,24 +21,36 @@ export declare enum ComputedEnum {
     J = \\"12\\",
     K = 1
 }
+export { ComputedEnum, SomeEnum };
+export declare enum DirectExportEnum {
+    HI = \\"HELLO\\",
+    WD = \\"WORLD\\"
+}
+declare enum DefaultExportConstEnum {
+    X = 0
+}
+export default DefaultExportConstEnum;
+declare const enum NonExportConstEnum {
+    A = 666,
+    B = 888
+}
 declare enum NonExportEnum {
     A = 0,
     B = 1
 }
-declare function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum): SomeEnum.D | ComputedEnum | NonExportEnum;
-export default SomeFunc;
+export declare function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum): SomeEnum.D | ComputedEnum | NonExportConstEnum.A | NonExportEnum.B;
 "
 `;
 
 exports[`transform export const enum into object literal test-case/const-enum.js 1`] = `
-"export const SomeEnum = {
+"const SomeEnum = {
     A: 0,
     B: 1,
     C: \\"hello\\",
     D: 1000,
     E: 1001
 };
-export const ComputedEnum = {
+const ComputedEnum = {
     A: 0,
     B: 1,
     C: 2,
@@ -51,21 +63,34 @@ export const ComputedEnum = {
     J: \\"12\\",
     K: 1
 };
+export { ComputedEnum, SomeEnum };
+export const DirectExportEnum = {
+    HI: \\"HELLO\\",
+    WD: \\"WORLD\\"
+};
+const DefaultExportConstEnum = {
+    X: 0
+};
+export default DefaultExportConstEnum;
 const Value = 0.5;
+var NonExportConstEnum;
+(function (NonExportConstEnum) {
+    NonExportConstEnum[NonExportConstEnum[\\"A\\"] = 666] = \\"A\\";
+    NonExportConstEnum[NonExportConstEnum[\\"B\\"] = 888] = \\"B\\";
+})(NonExportConstEnum || (NonExportConstEnum = {}));
 var NonExportEnum;
 (function (NonExportEnum) {
     NonExportEnum[NonExportEnum[\\"A\\"] = 0] = \\"A\\";
     NonExportEnum[NonExportEnum[\\"B\\"] = 1] = \\"B\\";
 })(NonExportEnum || (NonExportEnum = {}));
-function SomeFunc(inlineSomeEnum, inlineComputedEnum) {
+export function SomeFunc(inlineSomeEnum, inlineComputedEnum) {
     if (inlineSomeEnum === 0 /* A */)
         return 1000 /* D */;
     if (inlineComputedEnum === -2 /* D */)
         return 4 /* E */;
-    return Math.random() > Value ? NonExportEnum.A : NonExportEnum.B;
+    return Math.random() > Value ? 666 /* A */ : NonExportEnum.B;
 }
-export default SomeFunc;
 //# sourceMappingURL=const-enum.js.map"
 `;
 
-exports[`transform export const enum into object literal test-case/const-enum.js.map 1`] = `"{\\"version\\":3,\\"file\\":\\"const-enum.js\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"const-enum.ts\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,MAAM,OAAY,QAAQ;IACxB,IAAC;IACD,IAAC;IACD,UAAW;IACX,OAAQ;IACR,OAAC;EACF;AAED,MAAM,OAAY,YAAY;IAC5B,IAAC;IACD,IAAC;IACD,IAAC;IACD,KAAU;IACV,IAAU;IACV,KAAc;IACd,OAAuB;IACvB,KAA4B;IAC5B,MAAgB;IAChB,OAAa;IACb,IAAoB;EACrB;AAED,MAAM,KAAK,GAAG,GAAG,CAAC;AAElB,IAAK,aAGJ;AAHD,WAAK,aAAa;IAChB,2CAAC,CAAA;IACD,2CAAC,CAAA;AACH,CAAC,EAHI,aAAa,KAAb,aAAa,QAGjB;AAED,SAAS,QAAQ,CAAC,cAAwB,EAAE,kBAAgC;IAC1E,IAAI,cAAc,cAAe;QAAE,oBAAkB;IACrD,IAAI,kBAAkB,eAAmB;QAAE,iBAAsB;IACjE,OAAO,IAAI,CAAC,MAAM,EAAE,GAAG,KAAK,CAAC,CAAC,CAAC,aAAa,CAAC,CAAC,CAAC,CAAC,CAAC,aAAa,CAAC,CAAC,CAAC;AACnE,CAAC;AAED,eAAe,QAAQ,CAAC\\"}"`;
+exports[`transform export const enum into object literal test-case/const-enum.js.map 1`] = `"{\\"version\\":3,\\"file\\":\\"const-enum.js\\",\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"const-enum.ts\\"],\\"names\\":[],\\"mappings\\":\\"AAAA,MAAW,QAAQ;IACjB,IAAC;IACD,IAAC;IACD,UAAW;IACX,OAAQ;IACR,OAAC;EACF;AAED,MAAW,YAAY;IACrB,IAAC;IACD,IAAC;IACD,IAAC;IACD,KAAU;IACV,IAAU;IACV,KAAc;IACd,OAAuB;IACvB,KAA4B;IAC5B,MAAgB;IAChB,OAAa;IACb,IAAoB;EACrB;AACD,OAAO,EAAE,YAAY,EAAE,QAAQ,EAAE,CAAC;AAElC,MAAM,OAAY,gBAAgB;IAChC,WAAY;IACZ,WAAY;EACb;AAED,MAAW,sBAAsB;IAC/B,IAAC;EACF;AAED,eAAe,sBAAsB,CAAC;AAEtC,MAAM,KAAK,GAAG,GAAG,CAAC;AAElB,IAAW,kBAGV;AAHD,WAAW,kBAAkB;IAC3B,uDAAO,CAAA;IACP,uDAAO,CAAA;AACT,CAAC,EAHU,kBAAkB,KAAlB,kBAAkB,QAG5B;AAED,IAAK,aAGJ;AAHD,WAAK,aAAa;IAChB,2CAAC,CAAA;IACD,2CAAC,CAAA;AACH,CAAC,EAHI,aAAa,KAAb,aAAa,QAGjB;AAED,MAAM,UAAU,QAAQ,CAAC,cAAwB,EAAE,kBAAgC;IACjF,IAAI,cAAc,cAAe;QAAE,oBAAkB;IACrD,IAAI,kBAAkB,eAAmB;QAAE,iBAAsB;IACjE,OAAO,IAAI,CAAC,MAAM,EAAE,GAAG,KAAK,CAAC,CAAC,aAAsB,CAAC,CAAC,aAAa,CAAC,CAAC,CAAC;AACxE,CAAC\\"}"`;

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -5,7 +5,6 @@ export default function(program: ts.Program, pluginOptions?: unknown) {
   return (ctx: ts.TransformationContext) => {
     return (sourceFile: ts.SourceFile) => {
       return ts.visitEachChild(sourceFile, visitor, ctx);
-
       function visitor(node: ts.Node): ts.Node {
         if (!ts.isEnumDeclaration(node)) {
           return ts.visitEachChild(node, visitor, ctx);
@@ -16,7 +15,9 @@ export default function(program: ts.Program, pluginOptions?: unknown) {
         }
 
         if (!hasModifier(node, ts.SyntaxKind.ExportKeyword)) {
-          if (!getExportedNamesOfSource(program, sourceFile).includes(node.name.text)) {
+          const exportedNames = getExportedNamesOfSource(program, sourceFile);
+
+          if (!exportedNames.includes(node.name.text)) {
             return node;
           }
         }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,27 +1,31 @@
 import ts from 'typescript';
-import { evaluate, getModifier } from './utils';
+import { evaluate, getExportedNamesOfSource, hasModifier } from './utils';
 
 export default function(program: ts.Program, pluginOptions?: unknown) {
   return (ctx: ts.TransformationContext) => {
     return (sourceFile: ts.SourceFile) => {
-      const ambient = sourceFile.isDeclarationFile;
-
       return ts.visitEachChild(sourceFile, visitor, ctx);
 
       function visitor(node: ts.Node): ts.Node {
         if (!ts.isEnumDeclaration(node)) {
           return ts.visitEachChild(node, visitor, ctx);
         }
-        const exportModifier = getModifier(node, ts.SyntaxKind.ExportKeyword);
-        if (!exportModifier) return node;
-        const constModifier = getModifier(node, ts.SyntaxKind.ConstKeyword);
-        if (!constModifier) return node;
 
-        if (ambient) {
+        if (!hasModifier(node, ts.SyntaxKind.ConstKeyword)) {
+          return node;
+        }
+
+        if (!hasModifier(node, ts.SyntaxKind.ExportKeyword)) {
+          if (!getExportedNamesOfSource(program, sourceFile).includes(node.name.text)) {
+            return node;
+          }
+        }
+
+        if (sourceFile.isDeclarationFile) {
           return ts.visitEachChild(node, stripConstKeyword, ctx);
         }
 
-        return transformEnum(node, [exportModifier, constModifier]);
+        return transformEnum(node);
       }
     };
   };
@@ -30,7 +34,7 @@ export default function(program: ts.Program, pluginOptions?: unknown) {
     return node.kind === ts.SyntaxKind.ConstKeyword ? undefined : node;
   }
 
-  function transformEnum(node: ts.EnumDeclaration, modifiers: ts.Modifier[]) {
+  function transformEnum(node: ts.EnumDeclaration) {
     const members = node.members;
     const known = new Map<string, number | string>();
     const properties: ts.PropertyAssignment[] = [];
@@ -78,7 +82,7 @@ export default function(program: ts.Program, pluginOptions?: unknown) {
     }
 
     const result = ts.factory.createVariableStatement(
-      modifiers,
+      node.modifiers,
       ts.factory.createVariableDeclarationList(
         [
           ts.factory.createVariableDeclaration(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,22 +76,26 @@ export function hasModifier(node: ts.Node, modifier: ts.SyntaxKind) {
   );
 }
 
-const cachedMap = new WeakMap<ts.SourceFile, string[]>();
+const cachedNames = new WeakMap<ts.SourceFile, string[]>();
 export function getExportedNamesOfSource(program: ts.Program, sourceFile: ts.SourceFile) {
-  const cached = cachedMap.get(sourceFile);
+  const cached = cachedNames.get(sourceFile);
   if (cached) return cached;
 
   const typeChecker = program.getTypeChecker();
   const sourceSymbol = typeChecker.getSymbolAtLocation(sourceFile);
-  if (!sourceSymbol) return [];
+  let names: string[];
 
-  const symbols = typeChecker.getExportsOfModule(sourceSymbol).map(s => {
-    if (s.flags & ts.SymbolFlags.Alias) {
-      return typeChecker.getAliasedSymbol(s).name;
-    }
-    return s.name;
-  });
+  if (sourceSymbol) {
+    names = typeChecker.getExportsOfModule(sourceSymbol).map(s => {
+      if (s.flags & ts.SymbolFlags.Alias) {
+        return typeChecker.getAliasedSymbol(s).name;
+      }
+      return s.name;
+    });
+  } else {
+    names = [];
+  }
 
-  cachedMap.set(sourceFile, symbols);
-  return symbols;
+  cachedNames.set(sourceFile, names);
+  return names;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,9 +70,28 @@ export function evaluate(
   throw new Error('unexpected evaluation for enum member: ' + expr.getText);
 }
 
-export function getModifier(node: ts.Node, modifier: ts.SyntaxKind) {
+export function hasModifier(node: ts.Node, modifier: ts.SyntaxKind) {
   return (
-    node.modifiers
-    && node.modifiers.find((mod: ts.Modifier) => mod.kind === modifier)
+    node.modifiers?.some((mod: ts.Modifier) => mod.kind === modifier)
   );
+}
+
+const cachedMap = new WeakMap<ts.SourceFile, string[]>();
+export function getExportedNamesOfSource(program: ts.Program, sourceFile: ts.SourceFile) {
+  const cached = cachedMap.get(sourceFile);
+  if (cached) return cached;
+
+  const typeChecker = program.getTypeChecker();
+  const sourceSymbol = typeChecker.getSymbolAtLocation(sourceFile);
+  if (!sourceSymbol) return [];
+
+  const symbols = typeChecker.getExportsOfModule(sourceSymbol).map(s => {
+    if (s.flags & ts.SymbolFlags.Alias) {
+      return typeChecker.getAliasedSymbol(s).name;
+    }
+    return s.name;
+  });
+
+  cachedMap.set(sourceFile, symbols);
+  return symbols;
 }

--- a/test-case/const-enum.ts
+++ b/test-case/const-enum.ts
@@ -1,4 +1,4 @@
-export const enum SomeEnum {
+const enum SomeEnum {
   A,
   B,
   C = 'hello',
@@ -6,7 +6,7 @@ export const enum SomeEnum {
   E,
 }
 
-export const enum ComputedEnum {
+const enum ComputedEnum {
   A,
   B,
   C,
@@ -19,18 +19,33 @@ export const enum ComputedEnum {
   J = '1' + '2',
   K = B & 1000 + H / 2,
 }
+export { ComputedEnum, SomeEnum };
+
+export const enum DirectExportEnum {
+  HI = 'HELLO',
+  WD = 'WORLD',
+}
+
+const enum DefaultExportConstEnum {
+  X,
+}
+
+export default DefaultExportConstEnum;
 
 const Value = 0.5;
+
+const enum NonExportConstEnum {
+  A = 666,
+  B = 888,
+}
 
 enum NonExportEnum {
   A,
   B,
 }
 
-function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum) {
+export function SomeFunc(inlineSomeEnum: SomeEnum, inlineComputedEnum: ComputedEnum) {
   if (inlineSomeEnum === SomeEnum.A) return SomeEnum.D;
   if (inlineComputedEnum === ComputedEnum.D) return ComputedEnum.E;
-  return Math.random() > Value ? NonExportEnum.A : NonExportEnum.B;
+  return Math.random() > Value ? NonExportConstEnum.A : NonExportEnum.B;
 }
-
-export default SomeFunc;


### PR DESCRIPTION
Support export not in the modifier of EnumDeclaration.

Before this PR, only the following syntax work
```ts
export const enum WorkingEnum { A }  // will be transformed
```

After this PR, the following code works as well.
```ts
const enum MyEnum1 { A } // will be transformed
const enum MyEnum2 { A }  // will be transformed
export { MyEnum1, MyEnum2 as AliasEnum }
const enum AnotherEnum { A }  // will be transformed
export default AnotherEnum
const enum NotExportedEnum { A } // will not be transformed
```